### PR TITLE
Fixed: Use separate Zend_Code component.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,13 @@
     "homepage": "http://github.com/researchgate/injektor",
     "type": "library",
     "license": "Apache 2.0",
+    "minimum-stability": "RC",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "http://packages.zendframework.com/"
+        }
+    ],
     "authors": [
         {
             "name": "Bastian Hofmann",
@@ -14,7 +21,7 @@
     ],
     "require": {
         "php":">=5.3.2",
-        "zendframework/zendframework":"*"
+        "zendframework/zend-code":"*"
     },
     "autoload": {
         "psr-0": { "rg": "src/" }

--- a/composer.lock
+++ b/composer.lock
@@ -1,29 +1,16 @@
 {
-    "hash": "a45eae22fccf7036ee89115d74db8318",
+    "hash": "955f7bb987506a64cccea13b3e82b6a4",
     "packages": [
         {
-            "package": "zendframework/zendframework",
-            "version": "dev-master",
-            "alias-pretty-version": "2.0.x-dev",
-            "alias-version": "2.0.9999999.9999999-dev"
-        },
-        {
-            "package": "zendframework/zendframework",
-            "version": "dev-master",
-            "source-reference": "48bf0c42bc6c406681327b16064ab3cf1a644218"
-        },
-        {
-            "package": "zendframework/zendframework",
-            "version": "dev-master",
-            "alias-pretty-version": "2.0.x-dev",
-            "alias-version": "2.0.9999999.9999999-dev"
+            "package": "zendframework/zend-code",
+            "version": "2.0.0rc4"
         }
     ],
     "packages-dev": null,
     "aliases": [
 
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "RC",
     "stability-flags": [
 
     ]


### PR DESCRIPTION
This commit changes the previous composer dependency which references
the complete ZendFramework. Now we use the dedicated Zend_Code composer
package which is provided by Zend through it's own package repository.

All tests are still running, so this dependency change seems to be okay for me.
