### PR TITLE
Fix interfaces in same namespace

### DIFF
--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -335,7 +335,7 @@ class DependencyInjectionContainer {
             $parser = new PhpParser();
             $useStatements = $parser->parseClass($property->getDeclaringClass());
             if ($property->getDeclaringClass()->inNamespace()) {
-                $useStatements['__NAMESPACE__'] = $property->getDeclaringClass()->getNamespaceName();
+                $parentNamespace = $property->getDeclaringClass()->getNamespaceName();
             }
             // only process names which are not fully qualified, yet
             // fully qualified names must start with a \
@@ -348,11 +348,12 @@ class DependencyInjectionContainer {
                     } else {
                         $fullClassName = $useStatements[$loweredAlias];
                     }
-                } elseif (isset($useStatements['__NAMESPACE__']) && class_exists($useStatements['__NAMESPACE__'] . '\\' . $fullClassName)) {
-                    $fullClassName = $useStatements['__NAMESPACE__'] . '\\' . $fullClassName;
+                } elseif ($parentNamespace) {
+                    $fullClassName = $parentNamespace . '\\' . $fullClassName;
                 }
             }
         }
+
         return $fullClassName;
     }
 

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -332,14 +332,14 @@ class DependencyInjectionContainer {
      */
     public function getFullClassNameBecauseOfImports($property, $fullClassName) {
         if (!class_exists($fullClassName) || !interface_exists($fullClassName)) {
-            $parser = new PhpParser();
-            $useStatements = $parser->parseClass($property->getDeclaringClass());
-            if ($property->getDeclaringClass()->inNamespace()) {
-                $parentNamespace = $property->getDeclaringClass()->getNamespaceName();
-            }
             // only process names which are not fully qualified, yet
             // fully qualified names must start with a \
             if ('\\' !== $fullClassName[0]) {
+                $parser = new PhpParser();
+                $useStatements = $parser->parseClass($property->getDeclaringClass());
+                if ($property->getDeclaringClass()->inNamespace()) {
+                    $parentNamespace = $property->getDeclaringClass()->getNamespaceName();
+                }
                 $alias = (false === $pos = strpos($fullClassName, '\\')) ? $fullClassName : substr($fullClassName, 0, $pos);
 
                 if (isset($useStatements[$loweredAlias = strtolower($alias)])) {
@@ -348,13 +348,13 @@ class DependencyInjectionContainer {
                     } else {
                         $fullClassName = $useStatements[$loweredAlias];
                     }
-                } elseif ($parentNamespace) {
+                } elseif (isset($parentNamespace)) {
                     $fullClassName = $parentNamespace . '\\' . $fullClassName;
                 }
             }
         }
 
-        return $fullClassName;
+        return trim($fullClassName, '\\');
     }
 
     /**

--- a/src/rg/injektor/SimpleAnnotationReader.php
+++ b/src/rg/injektor/SimpleAnnotationReader.php
@@ -17,7 +17,7 @@ class SimpleAnnotationReader {
      * @throws InjectionException
      */
     public function getClassFromVarTypeHint($docComment) {
-        return trim($this->getClassFromTypeHint($docComment, '@var'), '\\');
+        return $this->getClassFromTypeHint($docComment, '@var');
     }
 
     /**

--- a/test/rg/injektor/DependencyInjectionContainerIssueTest.php
+++ b/test/rg/injektor/DependencyInjectionContainerIssueTest.php
@@ -13,7 +13,7 @@ namespace rg\injektor;
 
 include_once 'test_classes_issue.php';
 
-class DependencyInjectionContainerTestIssue extends \PHPUnit_Framework_TestCase
+class DependencyInjectionContainerIssueTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetInstanceOfClassWithUnderscores()
     {
@@ -21,5 +21,12 @@ class DependencyInjectionContainerTestIssue extends \PHPUnit_Framework_TestCase
         $dic = new DependencyInjectionContainer($config);
         $class = $dic->getInstanceOfClass('issue\ClassWithDependencyToClassWithUnderscores');
         $this->assertInstanceOf('issue\Class_With_Underscores', $class->getDependency());
+    }
+
+    public function testGetInstanceOfClassThatInjectsInterfaceInSameNamespace()
+    {
+        $dic = new DependencyInjectionContainer();
+        $class = $dic->getInstanceOfClass('issue9\name\A');
+        $this->assertInstanceOf('issue9\name\A', $class);
     }
 }

--- a/test/rg/injektor/test_classes_issue.php
+++ b/test/rg/injektor/test_classes_issue.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * test_classes_issue.php
- * 
+ *
  * @category
  * @author Johannes Brinksmeier <johannes.brinksmeier@googlemail.com>
  * @version $Id: $
@@ -44,5 +44,34 @@ namespace issue  {
         }
 
 
+    }
+}
+
+namespace issue9\name {
+
+    /**
+     * @implementedBy default issue9\name\D
+     * @implementedBy abc issue9\name\C
+     * @implementedBy abd issue9\name\D
+     */
+    interface B {
+
+    }
+
+    class C implements B {
+
+    }
+    class D implements B {
+
+    }
+
+    class A {
+
+        /**
+         * @inject
+         * @named abc
+         * @var B
+         */
+        protected $myB;
     }
 }

--- a/test/rg/injektor/test_classes_issue.php
+++ b/test/rg/injektor/test_classes_issue.php
@@ -20,12 +20,12 @@ namespace issue  {
 
         /**
          * @inject
-         * @var issue\Class_With_Underscores
+         * @var \issue\Class_With_Underscores
          */
         protected $dependency;
 
         /**
-         * @param issue\Class_With_Underscores $dependency
+         * @param \issue\Class_With_Underscores $dependency
          * @return ClassWithDependencyToClassWithUnderscores
          */
         public function setDependency($dependency)
@@ -36,7 +36,7 @@ namespace issue  {
         }
 
         /**
-         * @return issue\Class_With_Underscores
+         * @return \issue\Class_With_Underscores
          */
         public function getDependency()
         {


### PR DESCRIPTION
When you inject an interface of the same namespace the check for class_exists() fails.

```
namespace name\space;

class A {

    /**
     * @inject
     * @var B
     **/
    protected $property;
}
```
In this example B (which is an interface) refers to name\space\B, if it exists or not doesn't matter

I removed the check completely, because if we could not find a use statement and the class has a namespace, the class should always refer to parent-namespace + class-name.
The Exception is thrown anyway afterwards.

@bashofmann Please review.