### PR TITLE
Fix bug in detecting full classname

### DIFF
--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -331,7 +331,7 @@ class DependencyInjectionContainer {
      * @return string
      */
     public function getFullClassNameBecauseOfImports($property, $fullClassName) {
-        if (!class_exists($fullClassName) || !interface_exists($fullClassName)) {
+        if (!class_exists($fullClassName) && !interface_exists($fullClassName)) {
             // only process names which are not fully qualified, yet
             // fully qualified names must start with a \
             if ('\\' !== $fullClassName[0]) {


### PR DESCRIPTION
Only try to get full qualified name if class AND interface do not exist.
If one of them exist we are happy :)

This means right now, we always do the class-parsing and stuff even if the class exists, at least in the non factory mode.

@bashofmann 