### PR TITLE
feat: Better error message when instance of class cannot be retrieved

### DIFF
--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -835,8 +835,14 @@ class DependencyInjectionContainer {
         if ($namedClassName) {
             return $this->getInstanceOfClass($namedClassName, $arguments);
         }
+        
+        try {
+            $inst = $this->getInstanceOfClass($argument->getClass()->name, $arguments);
+        } catch (\Exception $error) {
+            throw new InjectionException('Error while injecting class: [' . $argument->getDeclaringClass()->name . '] method: [' . $argument->getDeclaringFunction()->name . '] argument: [' . $argument->name . ']', null, $error);
+        }
 
-        return $this->getInstanceOfClass($argument->getClass()->name, $arguments);
+        return $inst;
     }
 
     /**


### PR DESCRIPTION
Before:

```
rg\injektor\InjectionException: Can not instantiate abstract class rg\helper\MailSpecification
<stack>
```

After:

```
rg\injektor\InjectionException: Error while injecting class: [\SomeClass] method: [__construct] argument: [other]
<stack>

Caused by
rg\injektor\InjectionException: Error while injecting class: [\OtherService] method: [__construct] argument: [timeout]
<stack>

Caused by
rg\injektor\InjectionException: Error while injecting class: [\MockTimeoutLock] method: [__construct] argument: [test]
<stack>

Caused by
rg\injektor\InjectionException: Can not instantiate abstract class \TestSomething
<stack>
```