### PR TITLE
Added template annotations to getInstanceOfClass methods

### DIFF
--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -139,9 +139,12 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param string $fullClassName
+     * @template InstanceType
+     *
+     * @param class-string<InstanceType> $fullClassName
      * @param array $constructorArguments
-     * @return object
+     *
+     * @return InstanceType
      */
     public function getInstanceOfClass($fullClassName, array $constructorArguments = array()) {
         $this->iterationDepth++;

--- a/src/rg/injektor/FactoryDependencyInjectionContainer.php
+++ b/src/rg/injektor/FactoryDependencyInjectionContainer.php
@@ -16,19 +16,22 @@ class FactoryDependencyInjectionContainer extends DependencyInjectionContainer {
     public static $prefix = '';
 
     /**
-     * @param string $className
+     * @template InstanceType
+     *
+     * @param class-string<InstanceType> $fullClassName
      * @param array $constructorArguments
-     * @return object
+     *
+     * @return InstanceType
      */
-    public function getInstanceOfClass($className, array $constructorArguments = array()) {
-        $fullFactoryClassName = $this->getFullFactoryClassName($className);
-        $factoryClassName = $this->getFactoryClassName($className);
+    public function getInstanceOfClass($fullClassName, array $constructorArguments = array()) {
+        $fullFactoryClassName = $this->getFullFactoryClassName($fullClassName);
+        $factoryClassName = $this->getFactoryClassName($fullClassName);
 
         if ($this->factoryClassExists($fullFactoryClassName, $factoryClassName)) {
             return $fullFactoryClassName::getInstance($constructorArguments);
         }
 
-        return parent::getInstanceOfClass($className, $constructorArguments);
+        return parent::getInstanceOfClass($fullClassName, $constructorArguments);
     }
 
     /**

--- a/src/rg/injektor/FactoryOnlyDependencyInjectionContainer.php
+++ b/src/rg/injektor/FactoryOnlyDependencyInjectionContainer.php
@@ -12,17 +12,20 @@ namespace rg\injektor;
 class FactoryOnlyDependencyInjectionContainer extends FactoryDependencyInjectionContainer {
 
     /**
-     * @param string $className
+     * @template InstanceType
+     *
+     * @param class-string<InstanceType> $fullClassName
      * @param array $constructorArguments
+     *
+     * @return InstanceType
      * @throws InjectionException
-     * @return object
      */
-    public function getInstanceOfClass($className, array $constructorArguments = array()) {
-        $className = trim($className, '\\');
-        $classConfig = $this->config->getClassConfig($className);
-        $className = $this->getRealConfiguredClassName($classConfig, new \ReflectionClass($className));
-        $fullFactoryClassName = $this->getFullFactoryClassName($className);
-        $factoryClassName = $this->getFactoryClassName($className);
+    public function getInstanceOfClass($fullClassName, array $constructorArguments = array()) {
+        $fullClassName = trim($fullClassName, '\\');
+        $classConfig = $this->config->getClassConfig($fullClassName);
+        $fullClassName = $this->getRealConfiguredClassName($classConfig, new \ReflectionClass($fullClassName));
+        $fullFactoryClassName = $this->getFullFactoryClassName($fullClassName);
+        $factoryClassName = $this->getFactoryClassName($fullClassName);
 
         if ($this->factoryClassExists($fullFactoryClassName, $factoryClassName)) {
             return $fullFactoryClassName::getInstance($constructorArguments);


### PR DESCRIPTION
PHPStorm supports template annotations since some time: https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-release/#class_string_t 
as well as the recent psalm: https://psalm.dev/docs/annotating_code/templated_annotations/

Annotations would help developers with better code assistance and static code analysers as well

