### PR TITLE
Switch to laminas-code fork for PHP 8.0 and 8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=8.0",
     "doctrine/annotations": "^2.0.0",
-    "laminas/laminas-code": "^4.7.0",
+    "laminas/laminas-code": "4.7.x-dev",
     "psr/log": "^1.0.0"
   },
   "require-dev": {
@@ -29,6 +29,12 @@
   "suggest": {
     "ocramius/proxy-manager": "For lazy loading"
   },
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/researchgate/laminas-code-rg"
+    }
+  ],
   "autoload": {
     "psr-0": {
       "rg\\injektor": "src/"


### PR DESCRIPTION
The upstream only supports either PHP 7.4 to < 8.2 or PHP 8.1/8.2 so there is no upgrade path from PHP 8.0 straight to PHP 8.2 with a fixed lock file.