### PR TITLE
feat: add PHP 8's attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,22 +666,20 @@ use rg\injektor\attributes\Inject;
 
 class Foo
 {
-    /**
-     * @var Bar
-     * @named barOne
-     */
-    protected $bar;
+    #[Inject(named: 'barOne')]
+    protected Bar $bar;
 
-    /**
-     * @param Bar $one
-     * @param Bar $two
-     * @param Bar $default
-     * @named barOne $one
-     * @named barTwo $two
-     */
     #[Inject]
-    public function __construct(Bar $one, Bar $two, Bar $default)
-    {
+    public function __construct(
+        #[Inject(named: 'barOne')]
+        Bar $one,
+        #[Inject(named: 'barTwo')]
+        Bar $two,
+        // default implementation, requires #[Inject] on the constructor level
+        Bar $default,
+        #[Inject] // works the same as above, but doesn't require #[Inject] on the constructor level
+        Bar $default2,
+    ) {
 
     }
 }
@@ -773,22 +771,17 @@ use rg\injektor\attributes\Inject;
 
 class Foo
 {
-    /**
-     * @var Bar
-     * @named barOne
-     */
-    protected $bar;
+    #[Inject(named: 'barOne')]
+    protected Bar $bar;
 
-    /**
-     * @param Bar $one
-     * @param Bar $two
-     * @param Bar $default
-     * @named barOne $one
-     * @named barTwo $two
-     */
     #[Inject]
-    public function __construct(Bar $one, Bar $two, Bar $default)
-    {
+    public function __construct(
+        #[Inject(named: 'barOne')]
+        Bar $one,
+        #[Inject(named: 'barTwo')]
+        Bar $two,
+        Bar $default,
+    ) {
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -171,12 +171,11 @@ Constructor Injection
 ---------------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @param Bar $bar
-     */
+    #[Inject]
     public function __construct(Bar $bar)
     {
 
@@ -194,7 +193,7 @@ $dic->getInstanceOfClass('Foo');
 An instance of Bar will be injected as the constructor argument $bar. Of course Bar could use dependency injection as
 well. The container can inject any classes that are injectable because:
 
-- they have a @inject annotation at the constructor
+- they have a @inject annotation or `rg\injektor\attributes\Inject` attribute at the constructor
 - they have a constructor without arguments
 - they have no constructor
 - the arguments are optional
@@ -204,12 +203,11 @@ A constructor can be either a __construct method or a static getInstance method 
 and the __construct method is private or protected.
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @param Bar $bar
-     */
+    #[Inject]
     public function __construct(Bar $bar)
     {
 
@@ -239,13 +237,12 @@ Property Injection
 ------------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 class Bar
@@ -263,13 +260,12 @@ Inject Concrete Implementation
 ------------------------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -301,13 +297,12 @@ Using Provider Classes
 ----------------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -349,13 +344,12 @@ Passing fixed data to providers
 -------------------------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -374,9 +368,7 @@ class BarImpl implements Bar
 class BarProvider implements rg\injektor\Provider
 {
 
-    /**
-     * @inject
-     */
+    #[Inject]
     public function __construct(SomeClass $someClass, $foo)
     {
     }
@@ -410,13 +402,12 @@ Inject as Singleton
 -------------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -449,11 +440,8 @@ That means in this example:
 ```php
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -480,11 +468,8 @@ Injecting as service
 ```php
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -512,13 +497,12 @@ You can also configure this in the dependecy injection configuration instead of 
 In contrast to singletons, In a service this example
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     * @var Bar
-     */
-    protected $bar;
+    #[Inject]
+    protected Bar $bar;
 }
 
 /**
@@ -544,11 +528,11 @@ You can also configure the content of all or some parameters that the container 
 method in the configuration instead of letting the container guess them from typehints:
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     */
+    #[Inject]
     public function __construct($bar)
     {
 
@@ -565,9 +549,7 @@ class Bar
 
     }
 
-    /**
-     * @inject
-     */
+    #[Inject]
     public static function getInstance($foo, $buzz)
     {
 
@@ -602,6 +584,8 @@ Configuration:
 Alternatively you can also configure this with annotations
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
     /**
@@ -631,9 +615,7 @@ class Bar
 
     }
 
-    /**
-     * @inject
-     */
+    #[Inject]
     public static function getInstance($foo, $buzz)
     {
 
@@ -649,11 +631,11 @@ Pass additional parameters on runtime
 You also can pass some values to the new instance on runtime.
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     */
+    #[Inject]
     public function __construct($val, Bar $bar, Buzz $buzz)
     {
 
@@ -680,6 +662,8 @@ Named injection
 ---------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
     /**
@@ -689,13 +673,13 @@ class Foo
     protected $bar;
 
     /**
-     * @inject
      * @param Bar $one
      * @param Bar $two
      * @param Bar $default
      * @named barOne $one
      * @named barTwo $two
      */
+    #[Inject]
     public function __construct(Bar $one, Bar $two, Bar $default)
     {
 
@@ -785,6 +769,8 @@ Named providers
 ---------------
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
     /**
@@ -794,13 +780,13 @@ class Foo
     protected $bar;
 
     /**
-     * @inject
      * @param Bar $one
      * @param Bar $two
      * @param Bar $default
      * @named barOne $one
      * @named barTwo $two
      */
+    #[Inject]
     public function __construct(Bar $one, Bar $two, Bar $default)
     {
     }
@@ -906,11 +892,11 @@ Call method on object instance
 The container can also call methods on instances an inject all method arguments
 
 ```php
+use rg\injektor\attributes\Inject;
+
 class Foo
 {
-    /**
-     * @inject
-     */
+    #[Inject]
     public function doSomething(Bar $bar)
     {
     }
@@ -930,12 +916,11 @@ Of course you can also use named injections.
 It is also possible to add additional values to the method call, like with object creation:
 
 ```php
+use rg\injektor\attributes\Inject;
 
 class Foo
 {
-    /**
-     * @inject
-     */
+    #[Inject]
     public function doSomething(Bar $bar, $foo)
     {
     }

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -659,13 +659,13 @@ class DependencyInjectionContainer {
      * @return bool
      */
     public function isConfiguredAsService(array $classConfig, \ReflectionClass $classReflection) {
+        if (isset($classConfig['service'])) {
+            return (bool) $classConfig['service'];
+        }
+
         $attributes = $classReflection->getAttributes(Service::class);
         if ($attributes !== []) {
             return true;
-        }
-
-        if (isset($classConfig['service'])) {
-            return (bool) $classConfig['service'];
         }
 
         $classComment = $classReflection->getDocComment();

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -21,6 +21,7 @@ use ReflectionParameter;
 use ReflectionProperty;
 use rg\injektor\annotations\Named;
 use rg\injektor\attributes\Inject;
+use rg\injektor\attributes\Service;
 use UnexpectedValueException;
 use function get_class;
 use function method_exists;
@@ -650,6 +651,11 @@ class DependencyInjectionContainer {
      * @return bool
      */
     public function isConfiguredAsService(array $classConfig, \ReflectionClass $classReflection) {
+        $attributes = $classReflection->getAttributes(Service::class);
+        if ($attributes !== []) {
+            return true;
+        }
+
         if (isset($classConfig['service'])) {
             return (bool) $classConfig['service'];
         }

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -490,13 +490,13 @@ class DependencyInjectionContainer {
                     $params[$param->name] = $param->value;
                 }
 
-                $namedAnnotation = new Named();
-                $namedAnnotation->setName($inst->named);
-                $namedAnnotation->setClassName($inst->className);
-                $namedAnnotation->setParameters($params);
+                $namedAttribute = new Named();
+                $namedAttribute->setName($inst->named);
+                $namedAttribute->setClassName($inst->className);
+                $namedAttribute->setParameters($params);
 
-                $instanceConstructor = function () use ($namedAnnotation, $classReflection, $additionalArgumentsForProvider) {
-                    return $this->getRealClassInstanceFromProvider($namedAnnotation->getClassName(), $classReflection->name, array_merge($namedAnnotation->getParameters(), $additionalArgumentsForProvider));
+                $instanceConstructor = function () use ($namedAttribute, $classReflection, $additionalArgumentsForProvider) {
+                    return $this->getRealClassInstanceFromProvider($namedAttribute->getClassName(), $classReflection->name, array_merge($namedAttribute->getParameters(), $additionalArgumentsForProvider));
                 };
 
                 if ($this->supportsLazyLoading && $this->config->isLazyLoading() && $this->isConfiguredAsLazy($classConfig, $classReflection)) {

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -24,6 +24,7 @@ use rg\injektor\attributes\Inject;
 use rg\injektor\attributes\Lazy;
 use rg\injektor\attributes\NoLazy;
 use rg\injektor\attributes\Service;
+use rg\injektor\attributes\Singleton;
 use UnexpectedValueException;
 use function get_class;
 use function method_exists;
@@ -640,6 +641,11 @@ class DependencyInjectionContainer {
     public function isConfiguredAsSingleton(array $classConfig, \ReflectionClass $classReflection) {
         if (isset($classConfig['singleton'])) {
             return (bool) $classConfig['singleton'];
+        }
+
+        $attributes = $classReflection->getAttributes(Singleton::class);
+        if ($attributes !== []) {
+            return true;
         }
 
         $classComment = $classReflection->getDocComment();

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -16,10 +16,12 @@ use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionAttribute;
+use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
 use rg\injektor\annotations\Named;
+use rg\injektor\attributes\ImplementedBy;
 use rg\injektor\attributes\Inject;
 use rg\injektor\attributes\Lazy;
 use rg\injektor\attributes\NoLazy;
@@ -145,7 +147,7 @@ class DependencyInjectionContainer {
             return $configuredInstance;
         }
 
-        $classReflection = new \ReflectionClass($fullClassName);
+        $classReflection = new ReflectionClass($fullClassName);
 
         if ($providedClass = $this->getProvidedConfiguredClass($classConfig, $classReflection)) {
             $this->log('Got provided instance [' . spl_object_hash($providedClass) . '] of class [' . get_class($providedClass) . ']');
@@ -229,12 +231,12 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param callable $instanceConstructor
      *
      * @return object
      */
-    private function createNewInstance(array $classConfig, \ReflectionClass $classReflection, $instanceConstructor) {
+    private function createNewInstance(array $classConfig, ReflectionClass $classReflection, $instanceConstructor) {
         if ($this->supportsLazyLoading && $this->config->isLazyLoading() && $this->isConfiguredAsLazy($classConfig, $classReflection)) {
             return $this->wrapInstanceWithLazyProxy($classReflection->getName(), $instanceConstructor);
         } else {
@@ -285,10 +287,10 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @return bool
      */
-    public function isSingleton(\ReflectionClass $classReflection) {
+    public function isSingleton(ReflectionClass $classReflection) {
         return $classReflection->hasMethod('__construct') &&
             !$classReflection->getMethod('__construct')->isPublic() &&
             $classReflection->hasMethod('getInstance') &&
@@ -297,7 +299,7 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param array $classConfig
      * @param array $defaultConstructorArguments
      * @param string $constructorMethod
@@ -328,7 +330,7 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param object $instance
      * @return object
      * @throws InjectionException
@@ -346,7 +348,7 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @throws InjectionException
      * @return array
      */
@@ -450,11 +452,11 @@ class DependencyInjectionContainer {
 
     /**
      * @param string $fullClassName
-     * @return \ReflectionClass
+     * @return ReflectionClass
      * @throws InjectionException
      */
     public function getClassReflection($fullClassName) {
-        $classReflection = new \ReflectionClass($fullClassName);
+        $classReflection = new ReflectionClass($fullClassName);
 
         if ($classReflection->isAbstract()) {
             throw new InjectionException('Can not instantiate abstract class ' . $fullClassName);
@@ -468,12 +470,12 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param string $name
      * @param array $additionalArgumentsForProvider
      * @return null|object
      */
-    public function getProvidedConfiguredClass($classConfig, \ReflectionClass $classReflection, $name = null, $additionalArgumentsForProvider = array()) {
+    public function getProvidedConfiguredClass($classConfig, ReflectionClass $classReflection, $name = null, $additionalArgumentsForProvider = array()) {
         if ($namedAnnotation = $this->getProviderClassName($classConfig, $classReflection, $name)) {
             $instanceConstructor = function () use ($namedAnnotation, $classReflection, $additionalArgumentsForProvider) {
                 return $this->getRealClassInstanceFromProvider($namedAnnotation->getClassName(), $classReflection->name, array_merge($namedAnnotation->getParameters(), $additionalArgumentsForProvider));
@@ -491,7 +493,7 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param string $name
      * @return annotations\Named
      */
@@ -518,10 +520,10 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @return string
      */
-    public function getRealConfiguredClassName($classConfig, \ReflectionClass $classReflection) {
+    public function getRealConfiguredClassName($classConfig, ReflectionClass $classReflection) {
         if (isset($classConfig['class'])) {
             return $classConfig['class'];
         }
@@ -535,14 +537,15 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param null $name
      * @return string
      */
-    private function getAnnotatedImplementationClass(\ReflectionClass $classReflection, $name = null) {
+    private function getAnnotatedImplementationClass(ReflectionClass $classReflection, $name = null) {
         $docComment = $classReflection->getDocComment();
 
-        if ($namedAnnotation = $this->getImplementedByAnnotation($docComment, $name)) {
+        $attributes = $classReflection->getAttributes(ImplementedBy::class);
+        if ($namedAnnotation = $this->getImplementedByAnnotation($attributes, $docComment, $name)) {
             return $namedAnnotation->getClassName();
         }
 
@@ -568,11 +571,30 @@ class DependencyInjectionContainer {
     }
 
     /**
+     * @param ReflectionAttribute[] $attributes
      * @param string $docComment
      * @param string $name
      * @return Named
      */
-    private function getImplementedByAnnotation($docComment, $name) {
+    private function getImplementedByAnnotation(array $attributes, $docComment, $name) {
+        $pickDefault = $name === null || 'default';
+
+        foreach ($attributes as $attr) {
+            if ($attr->getName() !== ImplementedBy::class) {
+                continue;
+            }
+
+            /** @var ImplementedBy $inst */
+            $inst = $attr->newInstance();
+            if ($inst->named === $name || ($inst->named === 'default' && $pickDefault)) {
+                $named = new Named();
+                $named->setName($name);
+                $named->setClassName($inst->className);
+
+                return $named;
+            }
+        }
+
         return $this->getMatchingAnnotationByNamedPatter($docComment, '@implementedBy', $name);
     }
 
@@ -635,10 +657,10 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @return bool
      */
-    public function isConfiguredAsSingleton(array $classConfig, \ReflectionClass $classReflection) {
+    public function isConfiguredAsSingleton(array $classConfig, ReflectionClass $classReflection) {
         if (isset($classConfig['singleton'])) {
             return (bool) $classConfig['singleton'];
         }
@@ -655,10 +677,10 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @return bool
      */
-    public function isConfiguredAsService(array $classConfig, \ReflectionClass $classReflection) {
+    public function isConfiguredAsService(array $classConfig, ReflectionClass $classReflection) {
         if (isset($classConfig['service'])) {
             return (bool) $classConfig['service'];
         }
@@ -675,10 +697,10 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @return bool
      */
-    public function isConfiguredAsLazy(array $classConfig, \ReflectionClass $classReflection) {
+    public function isConfiguredAsLazy(array $classConfig, ReflectionClass $classReflection) {
         // Force no lazy loading
         if ($this->isConfiguredAsNoLazy($classConfig, $classReflection)) {
             return false;
@@ -709,10 +731,10 @@ class DependencyInjectionContainer {
 
     /**
      * @param array $classConfig
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @return bool
      */
-    public function isConfiguredAsNoLazy(array $classConfig, \ReflectionClass $classReflection) {
+    public function isConfiguredAsNoLazy(array $classConfig, ReflectionClass $classReflection) {
         if (isset($classConfig['noLazy'])) {
             return (bool) $classConfig['noLazy'];
         }
@@ -750,12 +772,12 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param \ReflectionClass $classReflection
+     * @param ReflectionClass $classReflection
      * @param string $methodName
      * @return null|\ReflectionMethod
      * @throws InjectionException
      */
-    private function getMethodReflection(\ReflectionClass $classReflection, $methodName) {
+    private function getMethodReflection(ReflectionClass $classReflection, $methodName) {
         if (!$classReflection->hasMethod($methodName)) {
             if ($methodName === '__construct') {
                 return null;
@@ -929,7 +951,7 @@ class DependencyInjectionContainer {
     public function getNamedProvidedInstance(array $attributes, string $argumentClass, array $classConfig, $docComment, $argumentName = null, $additionalArgumentsForProvider = array()) {
         $implementationName = $this->getImplementationName($docComment, $attributes, $argumentName);
 
-        return $this->getProvidedConfiguredClass($classConfig, new \ReflectionClass($argumentClass), $implementationName, $additionalArgumentsForProvider);
+        return $this->getProvidedConfiguredClass($classConfig, new ReflectionClass($argumentClass), $implementationName, $additionalArgumentsForProvider);
     }
 
     /**
@@ -988,7 +1010,17 @@ class DependencyInjectionContainer {
      */
     private function getImplementingClassBecauseOfName($argumentClass, $classConfig, $name) {
         if (!isset($classConfig['named']) || !isset($classConfig['named'][$name])) {
-            $classReflection = new \ReflectionClass($argumentClass);
+            $classReflection = new ReflectionClass($argumentClass);
+
+            $attributes = $classReflection->getAttributes(ImplementedBy::class);
+            foreach ($attributes as $attr) {
+                /** @var ImplementedBy $inst */
+                $inst = $attr->newInstance();
+                if ($inst->named === $name) {
+                    return $inst->className;
+                }
+            }
+
             $annotatedConfigurationClassName = $this->getAnnotatedImplementationClass($classReflection, $name);
             if ($annotatedConfigurationClassName) {
                 return $annotatedConfigurationClassName;

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -15,10 +15,12 @@ use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionAttribute;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
 use rg\injektor\annotations\Named;
+use rg\injektor\attributes\Inject;
 use UnexpectedValueException;
 use function get_class;
 use function method_exists;
@@ -350,7 +352,8 @@ class DependencyInjectionContainer {
         $injectableProperties = array();
 
         foreach ($properties as $property) {
-            if ($this->isInjectable($property->getDocComment())) {
+            $attributes = $property->getAttributes(Inject::class);
+            if ($this->isInjectable($property->getDocComment(), $attributes)) {
                 if ($property->isPrivate()) {
                     throw new InjectionException('Property ' . $property->name . ' must not be private for property injection.');
                 }
@@ -749,7 +752,8 @@ class DependencyInjectionContainer {
     public function getMethodArguments(\ReflectionMethod $methodReflection, array $defaultArguments = array()) {
         $arguments = $methodReflection->getParameters();
 
-        $methodIsMarkedInjectible = $this->isInjectable($methodReflection->getDocComment());
+        $attributes = $methodReflection->getAttributes(Inject::class);
+        $methodIsMarkedInjectible = $this->isInjectable($methodReflection->getDocComment(), $attributes);
 
         $argumentValues = array();
 
@@ -929,11 +933,19 @@ class DependencyInjectionContainer {
     }
 
     /**
-     * @param $docComment
+     * @param string $docComment
+     * @param ReflectionAttribute[] $attributes
      * @return bool
      */
-    public function isInjectable($docComment) {
-        return strpos($docComment, '@inject') !== false;
+    public function isInjectable($docComment, $attributes = []) {
+        foreach ($attributes as $attr) {
+            if ($attr->getName() === Inject::class) {
+                return true;
+            }
+        }
+
+        // For backwards compatibility check with @inject doc annotation
+        return str_contains($docComment, '@inject');
     }
 
     /**

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -21,6 +21,8 @@ use ReflectionParameter;
 use ReflectionProperty;
 use rg\injektor\annotations\Named;
 use rg\injektor\attributes\Inject;
+use rg\injektor\attributes\Lazy;
+use rg\injektor\attributes\NoLazy;
 use rg\injektor\attributes\Service;
 use UnexpectedValueException;
 use function get_class;
@@ -690,6 +692,10 @@ class DependencyInjectionContainer {
             return (bool) $classConfig['lazy'];
         }
 
+        $attributes = $classReflection->getAttributes(Lazy::class);
+        if ($attributes !== []) {
+            return true;
+        }
         $classComment = $classReflection->getDocComment();
 
         return strpos($classComment, '@lazy') !== false;
@@ -703,6 +709,11 @@ class DependencyInjectionContainer {
     public function isConfiguredAsNoLazy(array $classConfig, \ReflectionClass $classReflection) {
         if (isset($classConfig['noLazy'])) {
             return (bool) $classConfig['noLazy'];
+        }
+
+        $attributes = $classReflection->getAttributes(NoLazy::class);
+        if ($attributes !== []) {
+            return true;
         }
 
         $classComment = $classReflection->getDocComment();

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -770,13 +770,19 @@ class DependencyInjectionContainer {
                 $argumentValues[$argument->name] = $this->getValueOfDefaultArgument($defaultArguments[$argument->name]);
             } else if ($argumentAttributes !== []) {
                 foreach ($argumentAttributes as $attr) {
+                    /** @var Inject $instance */
                     $instance = $attr->newInstance();
+
                     if ($instance->named !== null) {
                         if (array_key_exists($instance->named, $defaultArguments)) {
                             $argumentValues[$argument->name] = $this->getValueOfDefaultArgument($defaultArguments[$instance->named]);
                         } else {
                             $argumentValues[$argument->name] = $this->getInstanceOfArgument($argument);
                         }
+                    }
+
+                    if ($instance->overwriteParams !== []) {
+                        $argumentValues[$argument->name] = $this->getInstanceOfArgument($argument);
                     }
                 }
             } else if ($methodIsMarkedInjectible) {
@@ -846,6 +852,12 @@ class DependencyInjectionContainer {
      * @return array
      */
     public function getParamsFromTypeHint(ReflectionParameter $argument) {
+        $attributes = $argument->getAttributes(Inject::class);
+        $params = $this->getOverwrittenParamsFromAttributes($attributes);
+        if ($params !== []) {
+            return $params;
+        }
+
         return $this->annotationReader->getParamsFromTypeHint($argument->getDeclaringFunction()->getDocComment(), $argument->name, 'param');
     }
 
@@ -854,7 +866,32 @@ class DependencyInjectionContainer {
      * @return array
      */
     public function getParamsFromPropertyTypeHint(\ReflectionProperty $property) {
+        $attributes = $property->getAttributes(Inject::class);
+        $params = $this->getOverwrittenParamsFromAttributes($attributes);
+
+        if ($params !== []) {
+            return $params;
+        }
+
         return $this->annotationReader->getParamsFromTypeHint($property->getDocComment(), $property->name, 'var');
+    }
+
+    private function getOverwrittenParamsFromAttributes(array $attributes): array
+    {
+        $arguments = [];
+        foreach ($attributes as $attr) {
+            /** @var Inject $inst */
+            $inst = $attr->newInstance();
+            if ($inst->overwriteParams === []) {
+                continue;
+            }
+
+            foreach ($inst->overwriteParams as $arg) {
+                $arguments[$arg->name] = $arg->value;
+            }
+        }
+
+        return $arguments;
     }
 
     /**

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -380,9 +380,10 @@ class DependencyInjectionContainer {
         $arguments = $this->getParamsFromPropertyTypeHint($property);
 
         $argumentClassConfig = $this->config->getClassConfig($fullClassName);
-        $propertyInstance = $this->getNamedProvidedInstance($fullClassName, $argumentClassConfig, $property->getDocComment(), null, $arguments);
+        $attributes = $property->getAttributes(Inject::class);
+        $propertyInstance = $this->getNamedProvidedInstance($attributes, $fullClassName, $argumentClassConfig, $property->getDocComment(), null, $arguments);
         if (!$propertyInstance) {
-            $namedClass = $this->getNamedClassOfArgument($fullClassName, $property->getDocComment());
+            $namedClass = $this->getNamedClassOfArgument($attributes, $fullClassName, $property->getDocComment());
             if ($namedClass) {
                 $fullClassName = $namedClass;
             }
@@ -760,10 +761,24 @@ class DependencyInjectionContainer {
         $isNumericDefaultArguments = !(bool) count(array_filter(array_keys($defaultArguments), 'is_string'));
         foreach ($arguments as $key => $argument) {
             /** @var ReflectionParameter $argument */
+
+            $argumentAttributes = $argument->getAttributes(Inject::class);
+
             if ($isNumericDefaultArguments && array_key_exists($key, $defaultArguments)) {
                 $argumentValues[$argument->name] = $this->getValueOfDefaultArgument($defaultArguments[$key]);
             } else if (array_key_exists($argument->name, $defaultArguments)) {
                 $argumentValues[$argument->name] = $this->getValueOfDefaultArgument($defaultArguments[$argument->name]);
+            } else if ($argumentAttributes !== []) {
+                foreach ($argumentAttributes as $attr) {
+                    $instance = $attr->newInstance();
+                    if ($instance->named !== null) {
+                        if (array_key_exists($instance->named, $defaultArguments)) {
+                            $argumentValues[$argument->name] = $this->getValueOfDefaultArgument($defaultArguments[$instance->named]);
+                        } else {
+                            $argumentValues[$argument->name] = $this->getInstanceOfArgument($argument);
+                        }
+                    }
+                }
             } else if ($methodIsMarkedInjectible) {
                 $argumentValues[$argument->name] = $this->getInstanceOfArgument($argument);
             } else if ($argument->isOptional()) {
@@ -811,12 +826,13 @@ class DependencyInjectionContainer {
 
         $arguments = $this->getParamsFromTypeHint($argument);
 
-        $providedInstance = $this->getNamedProvidedInstance($className, $argumentClassConfig, $argument->getDeclaringFunction()->getDocComment(), $argument->name, $arguments);
+        $attributes = $argument->getAttributes(Inject::class);
+        $providedInstance = $this->getNamedProvidedInstance($attributes, $className, $argumentClassConfig, $argument->getDeclaringFunction()->getDocComment(), $argument->name, $arguments);
         if ($providedInstance) {
             return $providedInstance;
         }
 
-        $namedClassName = $this->getNamedClassOfArgument($className, $argument->getDeclaringFunction()->getDocComment(), $argument->name);
+        $namedClassName = $this->getNamedClassOfArgument($attributes, $className, $argument->getDeclaringFunction()->getDocComment(), $argument->name);
 
         if ($namedClassName) {
             return $this->getInstanceOfClass($namedClassName, $arguments);
@@ -842,6 +858,7 @@ class DependencyInjectionContainer {
     }
 
     /**
+     * @param ReflectionAttribute[] $attributes
      * @param string $argumentClass
      * @param array $classConfig
      * @param string$docComment
@@ -849,22 +866,23 @@ class DependencyInjectionContainer {
      * @param array $additionalArgumentsForProvider
      * @return null|object
      */
-    public function getNamedProvidedInstance($argumentClass, array $classConfig, $docComment, $argumentName = null, $additionalArgumentsForProvider = array()) {
-        $implementationName = $this->getImplementationName($docComment, $argumentName);
+    public function getNamedProvidedInstance(array $attributes, string $argumentClass, array $classConfig, $docComment, $argumentName = null, $additionalArgumentsForProvider = array()) {
+        $implementationName = $this->getImplementationName($docComment, $attributes, $argumentName);
 
         return $this->getProvidedConfiguredClass($classConfig, new \ReflectionClass($argumentClass), $implementationName, $additionalArgumentsForProvider);
     }
 
     /**
+     * @param ReflectionAttribute[] $attributes
      * @param string $argumentClass
      * @param string $docComment
      * @param string $argumentName
      * @return string
      */
-    public function getNamedClassOfArgument($argumentClass, $docComment, $argumentName = null) {
+    public function getNamedClassOfArgument(array $attributes, $argumentClass, $docComment, $argumentName = null) {
         $argumentClassConfig = $this->config->getClassConfig($argumentClass);
 
-        $implementationName = $this->getImplementationName($docComment, $argumentName);
+        $implementationName = $this->getImplementationName($docComment, $attributes, $argumentName);
 
         if ($implementationName) {
             return $this->getImplementingClassBecauseOfName($argumentClass, $argumentClassConfig, $implementationName);
@@ -874,10 +892,20 @@ class DependencyInjectionContainer {
 
     /**
      * @param string $docComment
+     * @param ReflectionAttribute[] $attributes
      * @param string $argumentName
      * @return string
      */
-    public function getImplementationName($docComment, $argumentName) {
+    public function getImplementationName($docComment, array $attributes = [], $argumentName) {
+        foreach ($attributes as $attr) {
+            if ($attr->getName() === Inject::class) {
+                $inject = $attr->newInstance();
+                if ($inject->named !== null) {
+                    return $inject->named;
+                }
+            }
+        }
+
         $matches = array();
         $pattern = '@named\s+([a-zA-Z0-9\\\]+)';
         if ($argumentName) {

--- a/src/rg/injektor/DependencyInjectionContainer.php
+++ b/src/rg/injektor/DependencyInjectionContainer.php
@@ -25,6 +25,7 @@ use rg\injektor\attributes\ImplementedBy;
 use rg\injektor\attributes\Inject;
 use rg\injektor\attributes\Lazy;
 use rg\injektor\attributes\NoLazy;
+use rg\injektor\attributes\ProvidedBy;
 use rg\injektor\attributes\Service;
 use rg\injektor\attributes\Singleton;
 use UnexpectedValueException;
@@ -476,6 +477,36 @@ class DependencyInjectionContainer {
      * @return null|object
      */
     public function getProvidedConfiguredClass($classConfig, ReflectionClass $classReflection, $name = null, $additionalArgumentsForProvider = array()) {
+        $pickDefault = $name === null || $name === 'default';
+
+        $attributes = $classReflection->getAttributes(ProvidedBy::class);
+        foreach ($attributes as $attr) {
+            /** @var ProvidedBy $inst */
+            $inst = $attr->newInstance();
+
+            if (($pickDefault && $inst->named === 'default') || $inst->named === $name) {
+                $params = [];
+                foreach ($inst->overwriteParams as $param) {
+                    $params[$param->name] = $param->value;
+                }
+
+                $namedAnnotation = new Named();
+                $namedAnnotation->setName($inst->named);
+                $namedAnnotation->setClassName($inst->className);
+                $namedAnnotation->setParameters($params);
+
+                $instanceConstructor = function () use ($namedAnnotation, $classReflection, $additionalArgumentsForProvider) {
+                    return $this->getRealClassInstanceFromProvider($namedAnnotation->getClassName(), $classReflection->name, array_merge($namedAnnotation->getParameters(), $additionalArgumentsForProvider));
+                };
+
+                if ($this->supportsLazyLoading && $this->config->isLazyLoading() && $this->isConfiguredAsLazy($classConfig, $classReflection)) {
+                    return $this->wrapInstanceWithLazyProxy($classReflection->name, $instanceConstructor);
+                } else {
+                    return $instanceConstructor();
+                }
+            }
+        }
+
         if ($namedAnnotation = $this->getProviderClassName($classConfig, $classReflection, $name)) {
             $instanceConstructor = function () use ($namedAnnotation, $classReflection, $additionalArgumentsForProvider) {
                 return $this->getRealClassInstanceFromProvider($namedAnnotation->getClassName(), $classReflection->name, array_merge($namedAnnotation->getParameters(), $additionalArgumentsForProvider));
@@ -515,7 +546,11 @@ class DependencyInjectionContainer {
             return $annotation;
         }
 
-        return $this->getProvidedByAnnotation($classReflection->getDocComment(), $name);
+        return $this->getProvidedByAnnotation(
+            $classReflection->getAttributes(ProvidedBy::class),
+            $classReflection->getDocComment(),
+            $name,
+        );
     }
 
     /**
@@ -577,7 +612,7 @@ class DependencyInjectionContainer {
      * @return Named
      */
     private function getImplementedByAnnotation(array $attributes, $docComment, $name) {
-        $pickDefault = $name === null || 'default';
+        $pickDefault = $name === null || $name === 'default';
 
         foreach ($attributes as $attr) {
             if ($attr->getName() !== ImplementedBy::class) {
@@ -599,11 +634,36 @@ class DependencyInjectionContainer {
     }
 
     /**
+     * @param ReflectionAttribute[] $attributes
      * @param string $docComment
      * @param string $name
      * @return Named
      */
-    private function getProvidedByAnnotation($docComment, $name) {
+    private function getProvidedByAnnotation($attributes, $docComment, $name) {
+        $pickDefault = $name === null || $name === 'default';
+
+        foreach ($attributes as $attr) {
+            if ($attr->getName() !== ProvidedBy::class) {
+                continue;
+            }
+
+            /** @var ProvidedBy $inst */
+            $inst = $attr->newInstance();
+
+            if (($pickDefault && $inst->named === 'default') || $inst->named === $name) {
+                $named = new Named();
+                $named->setName($inst->named);
+                $named->setClassName($inst->className);
+                $params = [];
+                foreach ($inst->overwriteParams as $param) {
+                    $params[$param->name] = $param->value;
+                }
+                $named->setParameters($params);
+
+                return $named;
+            }
+        }
+
         return $this->getMatchingAnnotationByNamedPatter($docComment, '@providedBy', $name);
     }
 

--- a/src/rg/injektor/attributes/Arg.php
+++ b/src/rg/injektor/attributes/Arg.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class Arg
+{
+    public function __construct(
+        public string $name,
+        public mixed $value,
+    ) {
+    }
+}

--- a/src/rg/injektor/attributes/ImplementedBy.php
+++ b/src/rg/injektor/attributes/ImplementedBy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class ImplementedBy
+{
+    public function __construct(
+        public string $className,
+        public ?string $named = 'default',
+    ) {
+    }
+}

--- a/src/rg/injektor/attributes/Inject.php
+++ b/src/rg/injektor/attributes/Inject.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+class Inject
+{
+}

--- a/src/rg/injektor/attributes/Inject.php
+++ b/src/rg/injektor/attributes/Inject.php
@@ -6,7 +6,14 @@ namespace rg\injektor\attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
 class Inject
 {
+    public function __construct(
+        /**
+         * This can only be used in the context of a class property or method parameter.
+         */
+        public ?string $named = null,
+    ) {
+    }
 }

--- a/src/rg/injektor/attributes/Inject.php
+++ b/src/rg/injektor/attributes/Inject.php
@@ -16,7 +16,7 @@ class Inject
         public ?string $named = null,
         /**
          * This can only be used in the context of a class property or method parameter.
-         * @var Arg[] $overwriteParams
+         * @var Param[] $overwriteParams
          */
         public array   $overwriteParams = [],
     ) {

--- a/src/rg/injektor/attributes/Inject.php
+++ b/src/rg/injektor/attributes/Inject.php
@@ -14,6 +14,11 @@ class Inject
          * This can only be used in the context of a class property or method parameter.
          */
         public ?string $named = null,
+        /**
+         * This can only be used in the context of a class property or method parameter.
+         * @var Arg[] $overwriteParams
+         */
+        public array   $overwriteParams = [],
     ) {
     }
 }

--- a/src/rg/injektor/attributes/Lazy.php
+++ b/src/rg/injektor/attributes/Lazy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Lazy
+{
+}

--- a/src/rg/injektor/attributes/NoLazy.php
+++ b/src/rg/injektor/attributes/NoLazy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class NoLazy
+{
+}

--- a/src/rg/injektor/attributes/Param.php
+++ b/src/rg/injektor/attributes/Param.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace rg\injektor\attributes;
 
-use Attribute;
-
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class Arg
+/**
+ * This class represents a parameter with a name and a value in the context of #[Inject(overwriteParams: [])] attribute.
+ */
+class Param
 {
     public function __construct(
         public string $name,

--- a/src/rg/injektor/attributes/ProvidedBy.php
+++ b/src/rg/injektor/attributes/ProvidedBy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class ProvidedBy
+{
+    public function __construct(
+        public string $className,
+        public ?string $named = 'default',
+        /** @var Param[] $overwriteParams */
+        public array $overwriteParams = [],
+    ) {
+    }
+}

--- a/src/rg/injektor/attributes/Service.php
+++ b/src/rg/injektor/attributes/Service.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Service
+{
+}

--- a/src/rg/injektor/attributes/Singleton.php
+++ b/src/rg/injektor/attributes/Singleton.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rg\injektor\attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Singleton
+{
+}

--- a/src/rg/injektor/generators/InjectionParameter.php
+++ b/src/rg/injektor/generators/InjectionParameter.php
@@ -9,9 +9,11 @@
  */
 namespace rg\injektor\generators;
 
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
+use rg\injektor\attributes\Inject;
 use rg\injektor\Configuration;
 use rg\injektor\DependencyInjectionContainer;
 use rg\injektor\FactoryDependencyInjectionContainer;
@@ -25,6 +27,9 @@ class InjectionParameter {
     const MODE_STRING = 'string';
 
     private ReflectionParameter $parameter;
+
+    /** @var ReflectionAttribute[] */
+    protected array $attributes = [];
 
     protected array $classConfig;
 
@@ -69,6 +74,8 @@ class InjectionParameter {
         $this->additionalArguments = $this->dic->getParamsFromTypeHint($this->parameter);
         $this->mode = $mode;
 
+        $this->attributes = $parameter->getDeclaringFunction()->getAttributes(Inject::class);
+
         $this->analyze();
     }
 
@@ -100,7 +107,7 @@ class InjectionParameter {
     protected function analyze() {
         $argumentClass = null;
 
-        $isInjectable = $this->dic->isInjectable($this->docComment);
+        $isInjectable = $this->dic->isInjectable($this->docComment, $this->attributes);
 
         if (!empty($this->classConfig['params'][$this->name]['class'])) {
             $argumentClass = $this->classConfig['params'][$this->name]['class'];

--- a/src/rg/injektor/generators/InjectionParameter.php
+++ b/src/rg/injektor/generators/InjectionParameter.php
@@ -74,7 +74,10 @@ class InjectionParameter {
         $this->additionalArguments = $this->dic->getParamsFromTypeHint($this->parameter);
         $this->mode = $mode;
 
-        $this->attributes = $parameter->getDeclaringFunction()->getAttributes(Inject::class);
+        $this->attributes = $parameter->getAttributes(Inject::class);
+        if ($this->attributes === []) {
+            $this->attributes = $parameter->getDeclaringFunction()->getAttributes(Inject::class);
+        }
 
         $this->analyze();
     }
@@ -121,6 +124,7 @@ class InjectionParameter {
 
             try {
                 $namedClass = $this->dic->getNamedClassOfArgument(
+                    $this->attributes,
                     $argumentClass,
                     $this->docComment,
                     $this->nameForAnnotationParsing
@@ -134,7 +138,7 @@ class InjectionParameter {
                 $this->defaultValue = '\\' . $argumentClass . '::getDefaultInstance()';
             } else {
                 $providerClassName = $this->dic->getProviderClassName($this->config->getClassConfig($argumentClass), new ReflectionClass($argumentClass),
-                    $this->dic->getImplementationName($this->docComment, $this->nameForAnnotationParsing));
+                    $this->dic->getImplementationName($this->docComment, $this->attributes, $this->nameForAnnotationParsing));
                 if ($providerClassName && $providerClassName->getClassName()) {
                     $argumentFactory = $this->dic->getFullFactoryClassName($providerClassName->getClassName());
                     $this->className = $providerClassName->getClassName();

--- a/src/rg/injektor/generators/InjectionProperty.php
+++ b/src/rg/injektor/generators/InjectionProperty.php
@@ -10,6 +10,7 @@
 namespace rg\injektor\generators;
 
 use ReflectionProperty;
+use rg\injektor\attributes\Inject;
 use rg\injektor\Configuration;
 use rg\injektor\DependencyInjectionContainer;
 use const PHP_VERSION_ID;
@@ -33,6 +34,7 @@ class InjectionProperty extends InjectionParameter {
         $this->docComment = $this->property->getDocComment();
 
         $this->additionalArguments = $this->dic->getParamsFromPropertyTypeHint($this->property, 'var');
+        $this->attributes = $property->getAttributes(Inject::class);
         $this->analyze();
     }
 

--- a/test/rg/injektor/DependencyInjectionContainerTest.php
+++ b/test/rg/injektor/DependencyInjectionContainerTest.php
@@ -528,6 +528,22 @@ class DependencyInjectionContainerTest extends TestCase {
         $this->assertInstanceOf('rg\injektor\DICTestAnnotatedInterfaceImplTwo', $instance->two);
     }
 
+    public function testNamedAndDefault() {
+        $config = new Configuration(null, __DIR__ . '/_factories');
+
+        $config->setClassConfig('rg\injektor\DICTestAnnotatedInterface', [
+            'named' => [
+                'implOne' => 'rg\injektor\DICTestAnnotatedInterfaceImplOne',
+                'implTwo' => 'rg\injektor\DICTestAnnotatedInterfaceImplTwo'
+            ]
+        ]);
+        $dic = $this->getContainer($config);
+        $instance = $dic->getInstanceOfClass('rg\injektor\DICTestNamedAndDefault');
+
+        $this->assertInstanceOf('rg\injektor\DICTestAnnotatedInterfaceImplOne', $instance->one);
+        $this->assertInstanceOf('rg\injektor\DICTestAnnotatedInterfaceImplTwo', $instance->two);
+    }
+
     public function testNamedAnnotationWithAnnotationConfiguration() {
         $config = new Configuration(null, __DIR__ . '/_factories');
 

--- a/test/rg/injektor/FactoryDependencyInjectionContainerTest.php
+++ b/test/rg/injektor/FactoryDependencyInjectionContainerTest.php
@@ -9,6 +9,8 @@
  */
 namespace rg\injektor;
 
+use rg\injektor\attributes\Inject;
+
 class FactoryDependencyInjectionContainerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInjectionWithoutFactory() {
@@ -53,9 +55,9 @@ class FDICTestClassOne {
     public $three;
 
     /**
-     * @inject
      * @var \rg\injektor\FDICTestClassThree
      */
+    #[Inject]
     protected $four;
 
     /**
@@ -66,21 +68,21 @@ class FDICTestClassOne {
     }
 
     /**
-     * @inject
      * @param FDICTestClassTwo $two
      * @param FDICTestClassThree $three
      */
+    #[Inject]
     public function __construct(FDICTestClassTwo $two, FDICTestClassThree $three) {
         $this->two = $two;
         $this->three = $three;
     }
 
     /**
-     * @inject
      * @param FDICTestClassTwo $two
      * @param FDICTestClassThree $three
      * @return string
      */
+    #[Inject]
     public function getSomething(FDICTestClassTwo $two, FDICTestClassThree $three) {
         return $two->getSomething() . $three->getSomething();
     }
@@ -102,9 +104,9 @@ class FDICTestClassTwo {
     public $three;
 
     /**
-     * @inject
      * @param FDICTestClassThree $three
      */
+    #[Inject]
     public function __construct(FDICTestClassThree $three) {
         $this->three = $three;
     }

--- a/test/rg/injektor/InjectionLoopDetectionTest.php
+++ b/test/rg/injektor/InjectionLoopDetectionTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace rg\injektor;
 
+use rg\injektor\attributes\Inject;
+
 class InjectionLoopDetectionTest extends \PHPUnit\Framework\TestCase {
 
     public function testInjectionLoopDetectionA() {
@@ -54,9 +56,9 @@ class InjectionLoopDetectionTest extends \PHPUnit\Framework\TestCase {
 class InjectionLoopDetectionTest_DepA {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_DepB $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_DepB $dep) {
 
     }
@@ -65,9 +67,9 @@ class InjectionLoopDetectionTest_DepA {
 class InjectionLoopDetectionTest_DepB {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_DepC $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_DepC $dep) {
 
     }
@@ -76,9 +78,9 @@ class InjectionLoopDetectionTest_DepB {
 class InjectionLoopDetectionTest_DepC {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_DepA $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_DepA $dep) {
 
     }
@@ -87,9 +89,9 @@ class InjectionLoopDetectionTest_DepC {
 class InjectionLoopDetectionTest_DepD {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_DepD $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_DepD $dep) {
 
     }
@@ -98,9 +100,9 @@ class InjectionLoopDetectionTest_DepD {
 class InjectionLoopDetectionTest_DepE {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_DepD $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_DepD $dep) {
 
     }
@@ -109,10 +111,10 @@ class InjectionLoopDetectionTest_DepE {
 class InjectionLoopDetectionTest_NoRecA {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_NoRecB $dep
      * @param InjectionLoopDetectionTest_NoRecC $dep2
      */
+    #[Inject]
     public function __construct(
         InjectionLoopDetectionTest_NoRecC $dep3,
          InjectionLoopDetectionTest_NoRecBA $dep2,
@@ -124,9 +126,9 @@ class InjectionLoopDetectionTest_NoRecA {
 class InjectionLoopDetectionTest_NoRecBA {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_NoRecB $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_NoRecB $dep) {
 
     }
@@ -135,9 +137,9 @@ class InjectionLoopDetectionTest_NoRecBA {
 class InjectionLoopDetectionTest_NoRecB {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_NoRecD $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_NoRecD $dep) {
 
     }
@@ -146,9 +148,9 @@ class InjectionLoopDetectionTest_NoRecB {
 class InjectionLoopDetectionTest_NoRecC {
 
     /**
-     * @inject
      * @param InjectionLoopDetectionTest_NoRecD $dep
      */
+    #[Inject]
     public function __construct(InjectionLoopDetectionTest_NoRecD $dep) {
 
     }
@@ -156,9 +158,7 @@ class InjectionLoopDetectionTest_NoRecC {
 
 class InjectionLoopDetectionTest_NoRecD {
 
-    /**
-     * @inject
-     */
+    #[Inject]
     public function __construct() {
 
     }

--- a/test/rg/injektor/generators/FactoryGeneratorTest.php
+++ b/test/rg/injektor/generators/FactoryGeneratorTest.php
@@ -9,6 +9,7 @@
  */
 namespace rg\injektor\generators;
 
+use rg\injektor\attributes\Inject;
 use rg\injektor\FactoryDependencyInjectionContainer;
 use rg\injektor\Configuration;
 
@@ -417,9 +418,9 @@ class FGTestClassOne {
     public $three;
 
     /**
-     * @inject
      * @var \rg\injektor\generators\FGTestClassThree
      */
+    #[Inject]
     protected $four;
 
     /**
@@ -430,21 +431,21 @@ class FGTestClassOne {
     }
 
     /**
-     * @inject
      * @param FGTestClassTwo $two
      * @param FGTestClassThree $three
      */
+    #[Inject]
     public function __construct(FGTestClassTwo $two, FGTestClassThree $three) {
         $this->two = $two;
         $this->three = $three;
     }
 
     /**
-     * @inject
      * @param FGTestClassTwo $two
      * @param FGTestClassThree $three
      * @return string
      */
+    #[Inject]
     public function getSomething(FGTestClassTwo $two, FGTestClassThree $three) {
         return $two->getSomething() . $three->getSomething();
     }
@@ -458,9 +459,9 @@ class FGTestClassOne {
     }
 
     /**
-     * @inject
      * @param mixed $two
      */
+    #[Inject]
     public function methodRestriction($two = null) {
 
     }
@@ -473,9 +474,9 @@ class FGTestClassTwo {
      */
     public $three;
     /**
-     * @inject
      * @param FGTestClassThree $three
      */
+    #[Inject]
     public function __construct(FGTestClassThree $three) {
         $this->three = $three;
     }
@@ -499,9 +500,9 @@ class FGTestClassThree {
 class FGTestClassFour {
 
     /**
-     * @inject
      * @var \rg\injektor\generators\FGTestClassSimple
      */
+    #[Inject]
     protected $injectedProperty;
 
     private function __construct() {
@@ -509,11 +510,11 @@ class FGTestClassFour {
     }
 
     /**
-     * @inject
      * @static
      * @param FGTestClassSimple $simple
      * @return FGTestClassFour
      */
+    #[Inject]
     public static function getInstance(FGTestClassSimple $simple) {
         return new FGTestClassFour();
     }

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -12,6 +12,7 @@ namespace rg\injektor {
     use rg\injektor\attributes\Lazy;
     use rg\injektor\attributes\Param;
     use rg\injektor\attributes\Inject;
+    use rg\injektor\attributes\ProvidedBy;
     use rg\injektor\attributes\Service;
     use rg\injektor\attributes\Singleton;
 
@@ -172,9 +173,7 @@ namespace rg\injektor {
         }
     }
 
-    /**
-     * @providedBy \rg\injektor\DICProvidedTestClassNoTypeHintProvider
-     */
+    #[ProvidedBy(className: DICProvidedTestClassNoTypeHintProvider::class)]
     class DICProvidedTestClassNoTypeHint {
 
         public $one;
@@ -204,10 +203,14 @@ namespace rg\injektor {
         public $provided;
     }
 
-    /**
-     * @providedBy default \rg\injektor\DICProvidedTestClassNoTypeHintProvider {"one":1,"two":2}
-     * @providedBy someName \rg\injektor\DICProvidedTestClassNoTypeHintProvider {"one":3,"two":4}
-     */
+    #[ProvidedBy(className: DICProvidedTestClassNoTypeHintProvider::class, overwriteParams: [
+        new Param(name: 'one', value: 1),
+        new Param(name: 'two', value: 2),
+    ])]
+    #[ProvidedBy(className: DICProvidedTestClassNoTypeHintProvider::class, named: 'someName', overwriteParams: [
+        new Param(name: 'one', value: 3),
+        new Param(name: 'two', value: 4),
+    ])]
     class DICProvidedTestClassNoTypeHintNamed {
 
         public $one;

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -9,6 +9,7 @@
  */
 namespace rg\injektor {
 
+    use rg\injektor\attributes\Arg;
     use rg\injektor\attributes\Inject;
 
     require_once 'test_classes_not_injectable.php';
@@ -141,25 +142,29 @@ namespace rg\injektor {
 
         public $methodClass;
 
-        /**
-         * @var \rg\injektor\DICProvidedTestClassNoTypeHint {"one":"foo","two":"bar"}
-         */
-        #[Inject]
-        public $injectedProperty;
+        #[Inject(overwriteParams: [
+            new Arg(name: 'one', value: 'foo'),
+            new Arg(name: 'two', value: 'bar'),
+        ])]
+        public \rg\injektor\DICProvidedTestClassNoTypeHint $injectedProperty;
 
-        /**
-         * @param DICProvidedTestClassNoTypeHint $class {"one":"foo","two":"bar"}
-         */
-        #[Inject]
-        public function __construct(DICProvidedTestClassNoTypeHint $class) {
+        public function __construct(
+            #[Inject(overwriteParams: [
+                new Arg(name: 'one', value: 'foo'),
+                new Arg(name: 'two', value: 'bar'),
+            ])]
+            DICProvidedTestClassNoTypeHint $class
+        ) {
             $this->class = $class;
         }
 
-        /**
-         * @param DICProvidedTestClassNoTypeHint $class {"one":"foo","two":"bar"}
-         */
-        #[Inject]
-        public function someMethod(DICProvidedTestClassNoTypeHint $class) {
+        public function someMethod(
+            #[Inject(overwriteParams: [
+                new Arg(name: 'one', value: 'foo'),
+                new Arg(name: 'two', value: 'bar'),
+            ])]
+            DICProvidedTestClassNoTypeHint $class
+        ) {
             $this->methodClass = $class;
         }
     }
@@ -218,25 +223,29 @@ namespace rg\injektor {
 
         public $methodClass;
 
-        /**
-         * @var \rg\injektor\DICTestClassNoTypeHint {"one":"foo","two":"bar"}
-         */
-        #[Inject]
-        public $injectedProperty;
+        #[Inject(overwriteParams: [
+            new Arg(name: 'one', value: 'foo'),
+            new Arg(name: 'two', value: 'bar'),
+        ])]
+        public DICTestClassNoTypeHint $injectedProperty;
 
-        /**
-         * @param DICTestClassNoTypeHint $class {"one":"foo","two":"bar"}
-         */
-        #[Inject]
-        public function __construct(DICTestClassNoTypeHint $class) {
+        public function __construct(
+            #[Inject(overwriteParams: [
+                new Arg(name: 'one', value: 'foo'),
+                new Arg(name: 'two', value: 'bar'),
+            ])]
+            DICTestClassNoTypeHint $class
+        ) {
             $this->class = $class;
         }
 
-        /**
-         * @param DICTestClassNoTypeHint $class {"one":"foo","two":"bar"}
-         */
-        #[Inject]
-        public function someMethod(DICTestClassNoTypeHint $class) {
+        public function someMethod(
+            #[Inject(overwriteParams: [
+                new Arg(name: 'one', value: 'foo'),
+                new Arg(name: 'two', value: 'bar'),
+            ])]
+            DICTestClassNoTypeHint $class
+        ) {
             $this->methodClass = $class;
         }
     }

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -9,6 +9,8 @@
  */
 namespace rg\injektor {
 
+    use rg\injektor\attributes\Inject;
+
     require_once 'test_classes_not_injectable.php';
 
     class DICTestClassOne {
@@ -24,9 +26,9 @@ namespace rg\injektor {
         public $three;
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestClassThree
          */
+        #[Inject]
         protected $four;
 
         /**
@@ -37,31 +39,31 @@ namespace rg\injektor {
         }
 
         /**
-         * @inject
          * @param DICTestClassTwo $two
          * @param DICTestClassThree $three
          */
+        #[Inject]
         public function __construct(DICTestClassTwo $two, DICTestClassThree $three = null) {
             $this->two = $two;
             $this->three = $three;
         }
 
         /**
-         * @inject
          * @param DICTestClassTwo $two
          * @param DICTestClassThree $three
          * @return string
          */
+        #[Inject]
         public function getSomething(DICTestClassTwo $two, DICTestClassThree $three) {
             return $two->getSomething() . $three->getSomething();
         }
 
         /**
-         * @inject
          * @param DICTestClassTwo $two
          * @param $three
          * @return string
          */
+        #[Inject]
         public function getSomethingTwo(DICTestClassTwo $two, $three) {
             return $two->getSomething() . $three->getSomething();
         }
@@ -87,9 +89,9 @@ namespace rg\injektor {
         public $three;
 
         /**
-         * @inject
          * @param DICTestClassThree $three
          */
+        #[Inject]
         public function __construct(DICTestClassThree $three) {
             $this->three = $three;
         }
@@ -140,23 +142,23 @@ namespace rg\injektor {
         public $methodClass;
 
         /**
-         * @inject
          * @var \rg\injektor\DICProvidedTestClassNoTypeHint {"one":"foo","two":"bar"}
          */
+        #[Inject]
         public $injectedProperty;
 
         /**
-         * @inject
          * @param DICProvidedTestClassNoTypeHint $class {"one":"foo","two":"bar"}
          */
+        #[Inject]
         public function __construct(DICProvidedTestClassNoTypeHint $class) {
             $this->class = $class;
         }
 
         /**
-         * @inject
          * @param DICProvidedTestClassNoTypeHint $class {"one":"foo","two":"bar"}
          */
+        #[Inject]
         public function someMethod(DICProvidedTestClassNoTypeHint $class) {
             $this->methodClass = $class;
         }
@@ -179,19 +181,19 @@ namespace rg\injektor {
 
     class DICProvidedTestClassNoTypeHintNamedUserDefault {
         /**
-         * @inject
          * @var \rg\injektor\DICProvidedTestClassNoTypeHintNamed
          */
+        #[Inject]
         public $provided;
     }
 
     class DICProvidedTestClassNoTypeHintNamedUserSomeName {
 
         /**
-         * @inject
          * @var \rg\injektor\DICProvidedTestClassNoTypeHintNamed
          * @named someName
          */
+        #[Inject]
         public $provided;
     }
 
@@ -218,23 +220,23 @@ namespace rg\injektor {
         public $methodClass;
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestClassNoTypeHint {"one":"foo","two":"bar"}
          */
+        #[Inject]
         public $injectedProperty;
 
         /**
-         * @inject
          * @param DICTestClassNoTypeHint $class {"one":"foo","two":"bar"}
          */
+        #[Inject]
         public function __construct(DICTestClassNoTypeHint $class) {
             $this->class = $class;
         }
 
         /**
-         * @inject
          * @param DICTestClassNoTypeHint $class {"one":"foo","two":"bar"}
          */
+        #[Inject]
         public function someMethod(DICTestClassNoTypeHint $class) {
             $this->methodClass = $class;
         }
@@ -246,9 +248,7 @@ namespace rg\injektor {
 
         public $two;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public function __construct($one, $two) {
             $this->one = $one;
             $this->two = $two;
@@ -272,28 +272,26 @@ namespace rg\injektor {
 
     class DICTestClassNoParamTypeHint {
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public $two;
     }
 
     class DICTestClassPrivateProperty {
 
         /**
-         * @inject
          * @var DICTestClassNoConstructor
          */
+        #[Inject]
         private $two;
     }
 
     class DICTestClassPropertyDoubledAnnotation {
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestClassNoConstructor
          * @var \rg\injektor\DICTestClassPrivateProperty
          */
+        #[Inject]
         public $two;
     }
 
@@ -321,27 +319,27 @@ namespace rg\injektor {
         public $one;
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestAnnotatedInterface
          * @named implTwo
          */
+        #[Inject]
         public $two;
 
         /**
-         * @inject
          * @param DICTestAnnotatedInterface $one
          * @named implOne $one
          */
+        #[Inject]
         public function __construct(DICTestAnnotatedInterface $one) {
             $this->one = $one;
         }
 
         /**
-         * @inject
          * @param DICTestAnnotatedInterface $one
          * @named implOne $one
          * @return \rg\injektor\DICTestAnnotatedInterface
          */
+        #[Inject]
         public function doSomething(DICTestAnnotatedInterface $one) {
             return $one;
         }
@@ -364,27 +362,27 @@ namespace rg\injektor {
         public $one;
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestAnnotatedInterfaceNamedConfig
          * @named implTwo
          */
+        #[Inject]
         public $two;
 
         /**
-         * @inject
          * @param DICTestAnnotatedInterfaceNamedConfig $one
          * @named implOne $one
          */
+        #[Inject]
         public function __construct(DICTestAnnotatedInterfaceNamedConfig $one) {
             $this->one = $one;
         }
 
         /**
-         * @inject
          * @param DICTestAnnotatedInterfaceNamedConfig $one
          * @named implOne $one
          * @return \rg\injektor\DICTestAnnotatedInterfaceNamedConfig
          */
+        #[Inject]
         public function doSomething(DICTestAnnotatedInterfaceNamedConfig $one) {
             return $one;
         }
@@ -397,9 +395,9 @@ namespace rg\injektor {
         public $instance;
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestClassNoConstructor
          */
+        #[Inject]
         public $injectedProperty;
 
         private function __construct($foo, $instance) {
@@ -408,11 +406,11 @@ namespace rg\injektor {
         }
 
         /**
-         * @inject
          * @static
          * @param DICTestClassNoConstructor $instance
          * @return DICTestSingleton
          */
+        #[Inject]
         public static function getInstance(DICTestClassNoConstructor $instance) {
             return new static('foo', $instance);
         }
@@ -525,10 +523,10 @@ namespace rg\injektor {
         public $providedInterface2;
 
         /**
-         * @inject
          * @named impl1 $providedInterface1
          * @named impl2 $providedInterface2
          */
+        #[Inject]
         public function __construct(DICTestProvidedInterface $providedInterface1, DICTestProvidedInterface $providedInterface2) {
             $this->providedInterface1 = $providedInterface1;
             $this->providedInterface2 = $providedInterface2;
@@ -539,17 +537,15 @@ namespace rg\injektor {
 
         public $providedInterface;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public function __construct(DICTestSimpleProvidedInterface $providedInterface) {
             $this->providedInterface = $providedInterface;
         }
 
         /**
-         * @inject
          * @param DICTestSimpleProvidedInterface $providedInterface
          */
+        #[Inject]
         public function someMethod(DICTestSimpleProvidedInterface $providedInterface) {
             return $providedInterface;
         }
@@ -561,9 +557,7 @@ namespace rg\injektor {
 
         private $name;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public function __construct(DICTestProvidedDecorator $decorator, $name = null) {
             $this->decorator = $decorator;
             $this->name = $name;
@@ -588,9 +582,7 @@ namespace rg\injektor {
 
         private $name;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public function __construct(DICTestProvidedDecorator $decorator, $name = null) {
             $this->decorator = $decorator;
             $this->name = $name;
@@ -616,9 +608,7 @@ namespace rg\injektor {
 
         private $name;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public function __construct(DICTestSimpleProvidedDecorator $decorator, $name = null) {
             $this->decorator = $decorator;
             $this->name = $name;
@@ -640,9 +630,9 @@ namespace rg\injektor {
     class DICTestInterfaceDependency {
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestInterface
          */
+        #[Inject]
         public $dependency;
     }
 
@@ -651,9 +641,9 @@ namespace rg\injektor {
         public $dependency;
 
         /**
-         * @inject
          * @named impl1 $dependency
          */
+        #[Inject]
         public function __construct(DICTestProvidedInterface $dependency) {
             $this->dependency = $dependency;
         }
@@ -664,9 +654,9 @@ namespace rg\injektor {
         public $dependency;
 
         /**
-         * @inject
          * @named impl1 $dependency
          */
+        #[Inject]
         public function __construct(\rg\injektor\DICTestProvidedInterfaceNoConfig $dependency) {
             $this->dependency = $dependency;
         }
@@ -680,9 +670,9 @@ namespace rg\injektor {
         public $dependency;
 
         /**
-         * @inject
          * @param DICTestSimpleProvidedInterface $dependency
          */
+        #[Inject]
         public function __construct(DICTestSimpleProvidedInterface $dependency) {
             $this->dependency = $dependency;
         }
@@ -691,9 +681,9 @@ namespace rg\injektor {
     class DICTestAnnotatedInterfacePropertyInjection {
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestAnnotatedInterface
          */
+        #[Inject]
         public $dependency;
     }
 
@@ -708,19 +698,13 @@ namespace rg\injektor {
 
     class DICTestClassWithTypedProperties {
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public DICTestClassOne $one;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public \rg\injektor\DICTestClassTwo $two;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public ?DICTestClassThree $three;
     }
 }
@@ -732,6 +716,7 @@ namespace {
 
 namespace some\other\name\space {
 
+    use rg\injektor\attributes\Inject;
     use rg\injektor\DICTestClassNoConstructor;
 
     use rg\injektor\DICTestAnnotatedInterface as SomeInterface;
@@ -741,45 +726,45 @@ namespace some\other\name\space {
     class ClassPropertyInjectionWithUseStatementSupport {
 
         /**
-         * @inject
          * @var DICTestClassNoConstructor
          */
+        #[Inject]
         public $dependency;
 
         /**
-         * @inject
          * @var DICTestClassThatAlsoExistsInPublicNamespace
          */
+        #[Inject]
         public $dependencyWithOtherClassInPublicNamespace;
 
         /**
-         * @inject
          * @var \rg\injektor\DICTestClassThatAlsoExistsInPublicNamespace
          */
+        #[Inject]
         public $dependencyWithOtherClassInPublicNamespaceFq;
 
         /**
-         * @inject
          * @var \DICTestClassThatAlsoExistsInPublicNamespace
          */
+        #[Inject]
         public $dependencyWithOtherClassInPublicNamespaceFqPublic;
 
         /**
-         * @inject
          * @var DependencySameNamespace
          */
+        #[Inject]
         public $dependencySameNamespace;
 
         /**
-         * @inject
          * @var SomeInterface
          */
+        #[Inject]
         public $dependencyInterfaceWithAlias;
 
         /**
-         * @inject
          * @var injektorNamespace\DICTestAnnotatedSingleton
          */
+        #[Inject]
         public $dependencyWithAlias;
     }
 

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -9,6 +9,7 @@
  */
 namespace rg\injektor {
 
+    use rg\injektor\attributes\Lazy;
     use rg\injektor\attributes\Param;
     use rg\injektor\attributes\Inject;
     use rg\injektor\attributes\Service;
@@ -450,9 +451,7 @@ namespace rg\injektor {
         }
     }
 
-    /**
-     * @lazy
-     */
+    #[Lazy]
     class DICTestAnnotatedLazy {
         public function __construct($arg) {
 
@@ -471,10 +470,8 @@ namespace rg\injektor {
         }
     }
 
-    /**
-     * @lazy
-     */
     #[Service]
+    #[Lazy]
     class DICTestAnnotatedLazyService {
         public function __construct($arg) {
 

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -9,7 +9,7 @@
  */
 namespace rg\injektor {
 
-    use rg\injektor\attributes\Arg;
+    use rg\injektor\attributes\Param;
     use rg\injektor\attributes\Inject;
 
     require_once 'test_classes_not_injectable.php';
@@ -143,15 +143,15 @@ namespace rg\injektor {
         public $methodClass;
 
         #[Inject(overwriteParams: [
-            new Arg(name: 'one', value: 'foo'),
-            new Arg(name: 'two', value: 'bar'),
+            new Param(name: 'one', value: 'foo'),
+            new Param(name: 'two', value: 'bar'),
         ])]
         public \rg\injektor\DICProvidedTestClassNoTypeHint $injectedProperty;
 
         public function __construct(
             #[Inject(overwriteParams: [
-                new Arg(name: 'one', value: 'foo'),
-                new Arg(name: 'two', value: 'bar'),
+                new Param(name: 'one', value: 'foo'),
+                new Param(name: 'two', value: 'bar'),
             ])]
             DICProvidedTestClassNoTypeHint $class
         ) {
@@ -160,8 +160,8 @@ namespace rg\injektor {
 
         public function someMethod(
             #[Inject(overwriteParams: [
-                new Arg(name: 'one', value: 'foo'),
-                new Arg(name: 'two', value: 'bar'),
+                new Param(name: 'one', value: 'foo'),
+                new Param(name: 'two', value: 'bar'),
             ])]
             DICProvidedTestClassNoTypeHint $class
         ) {
@@ -224,15 +224,15 @@ namespace rg\injektor {
         public $methodClass;
 
         #[Inject(overwriteParams: [
-            new Arg(name: 'one', value: 'foo'),
-            new Arg(name: 'two', value: 'bar'),
+            new Param(name: 'one', value: 'foo'),
+            new Param(name: 'two', value: 'bar'),
         ])]
         public DICTestClassNoTypeHint $injectedProperty;
 
         public function __construct(
             #[Inject(overwriteParams: [
-                new Arg(name: 'one', value: 'foo'),
-                new Arg(name: 'two', value: 'bar'),
+                new Param(name: 'one', value: 'foo'),
+                new Param(name: 'two', value: 'bar'),
             ])]
             DICTestClassNoTypeHint $class
         ) {
@@ -241,8 +241,8 @@ namespace rg\injektor {
 
         public function someMethod(
             #[Inject(overwriteParams: [
-                new Arg(name: 'one', value: 'foo'),
-                new Arg(name: 'two', value: 'bar'),
+                new Param(name: 'one', value: 'foo'),
+                new Param(name: 'two', value: 'bar'),
             ])]
             DICTestClassNoTypeHint $class
         ) {

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -191,9 +191,8 @@ namespace rg\injektor {
 
         /**
          * @var \rg\injektor\DICProvidedTestClassNoTypeHintNamed
-         * @named someName
          */
-        #[Inject]
+        #[Inject(named: 'someName')]
         public $provided;
     }
 
@@ -318,30 +317,31 @@ namespace rg\injektor {
 
         public $one;
 
-        /**
-         * @var \rg\injektor\DICTestAnnotatedInterface
-         * @named implTwo
-         */
-        #[Inject]
-        public $two;
+        #[Inject(named: 'implTwo')]
+        public DICTestAnnotatedInterface $two;
 
-        /**
-         * @param DICTestAnnotatedInterface $one
-         * @named implOne $one
-         */
-        #[Inject]
-        public function __construct(DICTestAnnotatedInterface $one) {
+        public function __construct(
+            #[Inject(named: 'implOne')]
+            DICTestAnnotatedInterface $one
+        ) {
             $this->one = $one;
         }
 
-        /**
-         * @param DICTestAnnotatedInterface $one
-         * @named implOne $one
-         * @return \rg\injektor\DICTestAnnotatedInterface
-         */
-        #[Inject]
-        public function doSomething(DICTestAnnotatedInterface $one) {
+        public function doSomething(
+            #[Inject(named: 'implOne')]
+            DICTestAnnotatedInterface $one
+        ) {
             return $one;
+        }
+    }
+
+    class DICTestNamedAndDefault {
+        #[Inject]
+        public function __construct(
+            #[Inject(named: 'implOne')]
+            public DICTestAnnotatedInterface $one,
+            public DICTestAnnotatedInterfaceImplTwo $two, // Notice this is autowired, we require #[Inject] at the constructor
+        ) {
         }
     }
 
@@ -363,27 +363,21 @@ namespace rg\injektor {
 
         /**
          * @var \rg\injektor\DICTestAnnotatedInterfaceNamedConfig
-         * @named implTwo
          */
-        #[Inject]
+        #[Inject(named: 'implTwo')]
         public $two;
 
-        /**
-         * @param DICTestAnnotatedInterfaceNamedConfig $one
-         * @named implOne $one
-         */
-        #[Inject]
-        public function __construct(DICTestAnnotatedInterfaceNamedConfig $one) {
+        public function __construct(
+            #[Inject(named: 'implOne')]
+            DICTestAnnotatedInterfaceNamedConfig $one
+        ) {
             $this->one = $one;
         }
 
-        /**
-         * @param DICTestAnnotatedInterfaceNamedConfig $one
-         * @named implOne $one
-         * @return \rg\injektor\DICTestAnnotatedInterfaceNamedConfig
-         */
-        #[Inject]
-        public function doSomething(DICTestAnnotatedInterfaceNamedConfig $one) {
+        public function doSomething(
+            #[Inject(named: 'implOne')]
+            DICTestAnnotatedInterfaceNamedConfig $one
+        ) {
             return $one;
         }
     }
@@ -522,12 +516,12 @@ namespace rg\injektor {
 
         public $providedInterface2;
 
-        /**
-         * @named impl1 $providedInterface1
-         * @named impl2 $providedInterface2
-         */
-        #[Inject]
-        public function __construct(DICTestProvidedInterface $providedInterface1, DICTestProvidedInterface $providedInterface2) {
+        public function __construct(
+            #[Inject(named: 'impl1')]
+            DICTestProvidedInterface $providedInterface1,
+            #[Inject(named: 'impl2')]
+            DICTestProvidedInterface $providedInterface2
+        ) {
             $this->providedInterface1 = $providedInterface1;
             $this->providedInterface2 = $providedInterface2;
         }
@@ -640,11 +634,10 @@ namespace rg\injektor {
 
         public $dependency;
 
-        /**
-         * @named impl1 $dependency
-         */
-        #[Inject]
-        public function __construct(DICTestProvidedInterface $dependency) {
+        public function __construct(
+            #[Inject(named: 'impl1')]
+            DICTestProvidedInterface $dependency
+        ) {
             $this->dependency = $dependency;
         }
     }
@@ -653,11 +646,10 @@ namespace rg\injektor {
 
         public $dependency;
 
-        /**
-         * @named impl1 $dependency
-         */
-        #[Inject]
-        public function __construct(\rg\injektor\DICTestProvidedInterfaceNoConfig $dependency) {
+        public function __construct(
+            #[Inject(named: 'impl1')]
+            \rg\injektor\DICTestProvidedInterfaceNoConfig $dependency
+        ) {
             $this->dependency = $dependency;
         }
     }

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -11,6 +11,7 @@ namespace rg\injektor {
 
     use rg\injektor\attributes\Param;
     use rg\injektor\attributes\Inject;
+    use rg\injektor\attributes\Service;
 
     require_once 'test_classes_not_injectable.php';
 
@@ -433,9 +434,7 @@ namespace rg\injektor {
         }
     }
 
-    /**
-     * @service
-     */
+    #[Service]
     class DICTestAnnotatedService {
         public function __construct($arg) {
 
@@ -474,8 +473,8 @@ namespace rg\injektor {
 
     /**
      * @lazy
-     * @service
      */
+    #[Service]
     class DICTestAnnotatedLazyService {
         public function __construct($arg) {
 

--- a/test/rg/injektor/test_classes.php
+++ b/test/rg/injektor/test_classes.php
@@ -13,6 +13,7 @@ namespace rg\injektor {
     use rg\injektor\attributes\Param;
     use rg\injektor\attributes\Inject;
     use rg\injektor\attributes\Service;
+    use rg\injektor\attributes\Singleton;
 
     require_once 'test_classes_not_injectable.php';
 
@@ -421,9 +422,7 @@ namespace rg\injektor {
         }
     }
 
-    /**
-     * @singleton
-     */
+    #[Singleton]
     class DICTestAnnotatedSingleton {
 
     }

--- a/test/rg/injektor/test_classes_issue.php
+++ b/test/rg/injektor/test_classes_issue.php
@@ -51,13 +51,12 @@ namespace issue  {
 
 namespace issue9\name {
 
+    use rg\injektor\attributes\ImplementedBy;
     use rg\injektor\attributes\Inject;
 
-    /**
-     * @implementedBy default issue9\name\D
-     * @implementedBy abc issue9\name\C
-     * @implementedBy abd issue9\name\D
-     */
+    #[ImplementedBy(className: 'issue9\name\D', named: 'default')]
+    #[ImplementedBy(className: 'issue9\name\C', named: 'abc')]
+    #[ImplementedBy(className: 'issue9\name\D', named: 'abd')]
     interface B {
 
     }
@@ -81,10 +80,10 @@ namespace issue9\name {
 
 namespace issueImplementedByOrder\name {
 
-    /**
-     * @implementedBy abc issueImplementedByOrder\name\C
-     * @implementedBy default issueImplementedByOrder\name\D
-     */
+    use rg\injektor\attributes\ImplementedBy;
+
+    #[ImplementedBy(className: 'issueImplementedByOrder\name\D', named: 'default')]
+    #[ImplementedBy(className: 'issueImplementedByOrder\name\C', named: 'abc')]
     interface B {
 
     }

--- a/test/rg/injektor/test_classes_issue.php
+++ b/test/rg/injektor/test_classes_issue.php
@@ -8,6 +8,8 @@
  */
 namespace issue  {
 
+    use rg\injektor\attributes\Inject;
+
     interface Class_With_Underscores {
 
     }
@@ -19,9 +21,9 @@ namespace issue  {
     class ClassWithDependencyToClassWithUnderscores {
 
         /**
-         * @inject
          * @var \issue\Class_With_Underscores
          */
+        #[Inject]
         protected $dependency;
 
         /**
@@ -49,6 +51,8 @@ namespace issue  {
 
 namespace issue9\name {
 
+    use rg\injektor\attributes\Inject;
+
     /**
      * @implementedBy default issue9\name\D
      * @implementedBy abc issue9\name\C
@@ -68,10 +72,10 @@ namespace issue9\name {
     class A {
 
         /**
-         * @inject
          * @named abc
          * @var B
          */
+        #[Inject]
         protected $myB;
     }
 }

--- a/test/rg/injektor/test_classes_issue.php
+++ b/test/rg/injektor/test_classes_issue.php
@@ -72,10 +72,9 @@ namespace issue9\name {
     class A {
 
         /**
-         * @named abc
          * @var B
          */
-        #[Inject]
+        #[Inject(named: 'abc')]
         protected $myB;
     }
 }

--- a/test/rg/injektor/test_classes_not_injectable.php
+++ b/test/rg/injektor/test_classes_not_injectable.php
@@ -10,6 +10,8 @@
 namespace rg\injektor;
 
 use rg\injektor\attributes\ImplementedBy;
+use rg\injektor\attributes\Param;
+use rg\injektor\attributes\ProvidedBy;
 
 abstract class DICTestAbstractClass {
 
@@ -31,10 +33,12 @@ interface DICTestAnnotatedInterfaceNamedConfig {
 
 }
 
-/**
- * @providedBy impl1 rg\injektor\DICTestProvider {"name" : "impl1"}
- * @providedBy impl2 rg\injektor\DICTestProvider {"name" : "impl2"}
- */
+#[ProvidedBy(className: DICTestProvider::class, named: 'impl1', overwriteParams: [
+    new Param('name', 'impl1')
+])]
+#[ProvidedBy(className: DICTestProvider::class, named: 'impl2', overwriteParams: [
+    new Param('name', 'impl2')
+])]
 interface DICTestProvidedInterface {
 
 }
@@ -43,16 +47,12 @@ interface DICTestProvidedInterfaceNoConfig {
 
 }
 
-/**
- * @providedBy rg\injektor\DICSimpleTestProvider
- */
+#[ProvidedBy(className: DICSimpleTestProvider::class)]
 interface DICTestSimpleProvidedInterface {
 
 }
 
-/**
- * @providedBy rg\injektor\DICTestProvidedInterfaceImpl1
- */
+#[ProvidedBy(className: DICTestProvidedInterfaceImpl1::class)]
 interface DICTestInvalidProvidedInterface {
 
 }

--- a/test/rg/injektor/test_classes_not_injectable.php
+++ b/test/rg/injektor/test_classes_not_injectable.php
@@ -9,6 +9,8 @@
  */
 namespace rg\injektor;
 
+use rg\injektor\attributes\ImplementedBy;
+
 abstract class DICTestAbstractClass {
 
 }
@@ -17,18 +19,14 @@ interface DICTestInterface {
 
 }
 
-/**
- * @implementedBy rg\injektor\DICTestAnnotatedInterfaceImpl
- */
+#[ImplementedBy(className: DICTestAnnotatedInterfaceImpl::class)]
 interface DICTestAnnotatedInterface {
 
 }
 
-/**
- * @implementedBy default rg\injektor\DICTestAnnotatedInterfaceNamedConfigImpl
- * @implementedBy implOne rg\injektor\DICTestAnnotatedInterfaceNamedConfigImplOne
- * @implementedBy implTwo rg\injektor\DICTestAnnotatedInterfaceNamedConfigImplTwo
- */
+#[ImplementedBy(className: DICTestAnnotatedInterfaceNamedConfigImpl::class)]
+#[ImplementedBy(className: DICTestAnnotatedInterfaceNamedConfigImplOne::class, named: 'implOne')]
+#[ImplementedBy(className: DICTestAnnotatedInterfaceNamedConfigImplTwo::class, named: 'implTwo')]
 interface DICTestAnnotatedInterfaceNamedConfig {
 
 }

--- a/test/rg/injektor/test_classes_php80.php
+++ b/test/rg/injektor/test_classes_php80.php
@@ -10,24 +10,19 @@
 namespace rg\injektor {
 
     use PHPUnit\Framework\MockObject\MockObject;
+    use rg\injektor\attributes\Inject;
 
     require_once 'test_classes.php';
 
     class DICTestClassWithUnionTypedProperties {
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public DICTestClassOne|MockObject $one;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public \rg\injektor\DICTestClassTwo|MockObject $two;
 
-        /**
-         * @inject
-         */
+        #[Inject]
         public DICTestClassThree|MockObject|null $three;
     }
 }


### PR DESCRIPTION
This pull request enables the usage of PHP 8's attributes instead of docblock annotations, but keeps backwards compatibility with those.

## To-dos

* [x] Create `#[Inject]` attribute and let injektor discover injectables through it
* [x] Allow passing constructor overwrites to `#[Inject]` when dealing with class properties or method params
* [x] Add `named` property to the `#[Inject]` attribute, that behaves like `@named` does
* [x] Create `#[Service]` attribute
* [x] Create `#[ProvidedBy]` attribute
* [x] Create `#[ImplementedBy]` attribute
* [x] Create `#[Singleton]` attribute
* [x] Create `#[Lazy]` attribute
* [x] Create `#[NoLazy]` attribute

## How to use it

The following should work now:

```php
use rg\injektor\attributes\Inject;
use rg\injektor\attributes\Param;

class MyClass
{
    #[Inject]
    protected MyDependency $dep;

    #[Inject]
    public function __construct(
        AnotherDependency $dep,
        #[Inject(named: 'mdbDependencyInterface')]
        DependencyInterface $dep2,
    ) {
    }

    #[Inject]
    public function serviceMethod(YetAnotherDependency $dep)
    {
    }

    public function anotherServiceMethod(
        #[Inject(overwriteParams: [
              new Param('param1', 'some value'),
        ])]
        AnotherDependency $depInjectedAtParamLevel,
    ) {
    }
}
```